### PR TITLE
fix: use macos-15 (Sequoia) runner for VM acceptance test

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   acceptance:
     name: VM Acceptance
-    runs-on: macos-14
+    runs-on: macos-15
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

- Tart's `softnet` network component requires macOS Sequoia or newer
- `macos-14` runner is Sonoma — install was failing immediately with: `softnet: This software does not run on macOS versions older than Sequoia`
- Switching to `macos-15` (Sequoia, Apple Silicon) which satisfies Tart's requirement

## After merging

Re-tag to re-trigger the release pipeline:
```bash
git tag -d v0.1.0-beta.1
git push origin --delete v0.1.0-beta.1
./scripts/bump-version.sh set 0.1.0-beta.1
git push && git push --tags
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)