### PR TITLE
fix: add workflow_call trigger to validate.yml

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_call:
 
 jobs:
   # ── Job 1: Lint (fast, runs on Linux) ──────────────────────────────────────


### PR DESCRIPTION
## Summary

`release.yml` calls `validate.yml` as a reusable workflow using `uses: ./.github/workflows/validate.yml`. For this to work, `validate.yml` must declare `workflow_call:` in its `on:` triggers — it was missing this, causing the release pipeline to fail instantly with a workflow file configuration error.

One-line fix: add `workflow_call:` to the `on:` block.

## After merging

Re-tag to re-trigger the full release pipeline:
```bash
git tag -d v0.1.0-beta.1
git push origin --delete v0.1.0-beta.1
./scripts/bump-version.sh set 0.1.0-beta.1
git push && git push --tags
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)