### PR TITLE
fix: run release job when acceptance is skipped for pre-releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,9 @@ jobs:
     name: Create Release
     runs-on: ubuntu-latest
     needs: [validate, acceptance]
+    # Run if validate succeeded AND acceptance either succeeded or was skipped
+    # (acceptance is skipped for pre-release tags by design)
+    if: ${{ always() && needs.validate.result == 'success' && (needs.acceptance.result == 'success' || needs.acceptance.result == 'skipped') }}
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
## Summary

When a `workflow_call` job is skipped via an `if` condition, GitHub does not automatically allow dependent jobs to run — they also get skipped. The `release` job was being skipped for pre-release tags because `acceptance` was skipped.

Fix: explicit `if` on the `release` job:
```yaml
if: ${{ always() && needs.validate.result == 'success' && (needs.acceptance.result == 'success' || needs.acceptance.result == 'skipped') }}
```

This means:
- **Pre-release tag**: validate ✓ + acceptance skipped → release runs ✓  
- **Stable tag**: validate ✓ + acceptance ✓ → release runs ✓
- **Any failure**: release is blocked ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)