### PR TITLE
feat: Brewfile.vm for VM acceptance tests — excludes IDEs, keeps Docker

### DIFF
--- a/Brewfile.vm
+++ b/Brewfile.vm
@@ -1,0 +1,49 @@
+# Brewfile.vm — used by the VM acceptance test (scripts/vm-acceptance-test.sh)
+# Full environment minus the large JetBrains IDEs and Cursor, which exceed the
+# 50GB Tart base image disk limit. Everything else — CLI tools, Docker, iTerm2,
+# MongoDB Compass, fonts — is included and tested.
+#
+# IDEs omitted: cursor, goland, intellij-idea, pycharm
+# These are covered by the full Brewfile on a real machine.
+
+# ── Taps ─────────────────────────────────────────────────────────────────────
+tap "homebrew/cask-fonts"
+
+# ── CLI Utilities ────────────────────────────────────────────────────────────
+brew "git"
+brew "gh"               # GitHub CLI
+brew "vim"
+brew "fzf"
+brew "ripgrep"          # fast grep (rg)
+brew "fd"               # fast find
+brew "bat"              # better cat
+brew "tmux"
+brew "wget"
+brew "jq"               # JSON processor
+brew "tree"
+
+# ── Languages ────────────────────────────────────────────────────────────────
+brew "go"
+brew "pyenv"            # Python version manager
+brew "nvm"              # Node version manager
+brew "openjdk"
+brew "maven"
+
+# ── Cloud & DevOps ───────────────────────────────────────────────────────────
+brew "kubernetes-cli"   # kubectl
+brew "kind"             # local k8s clusters
+brew "helm"
+brew "terraform"
+brew "oci-cli"          # Oracle Cloud
+brew "doctl"            # DigitalOcean CLI
+
+# ── Databases ────────────────────────────────────────────────────────────────
+brew "mongosh"          # MongoDB shell
+
+# ── Fonts ────────────────────────────────────────────────────────────────────
+cask "font-meslo-lg-nerd-font"
+
+# ── GUI Apps ─────────────────────────────────────────────────────────────────
+cask "iterm2"
+cask "docker"
+cask "mongodb-compass"

--- a/scripts/vm-acceptance-test.sh
+++ b/scripts/vm-acceptance-test.sh
@@ -92,8 +92,8 @@ done
 echo "▶ Cloning repository into VM"
 vm_ssh "git clone https://github.com/amcheste/mac-dev-setup ~/Repos/amcheste/mac-dev-setup"
 
-echo "▶ Running setup.sh"
-vm_ssh "cd ~/Repos/amcheste/mac-dev-setup && bash setup.sh"
+echo "▶ Running setup.sh (using Brewfile.vm — excludes large IDEs)"
+vm_ssh "cd ~/Repos/amcheste/mac-dev-setup && BREWFILE=Brewfile.vm bash setup.sh"
 
 echo "▶ Copying acceptance-test.sh to VM"
 vm_scp "$SCRIPT_DIR/acceptance-test.sh" "/tmp/acceptance-test.sh"

--- a/setup.sh
+++ b/setup.sh
@@ -50,7 +50,10 @@ brew tap amcheste/mac-dev-setup https://github.com/amcheste/mac-dev-setup 2>/dev
 # ── Brew Bundle ──────────────────────────────────────────────────────────────
 echo ""
 echo "▶ Installing packages (this may take a few minutes)..."
-brew bundle --file="$REPO_DIR/Brewfile" \
+# BREWFILE env var allows alternate package lists (e.g. Brewfile.vm for VM tests)
+BREWFILE_PATH="${BREWFILE:-$REPO_DIR/Brewfile}"
+echo "  Using: $BREWFILE_PATH"
+brew bundle --file="$BREWFILE_PATH" \
     || { echo "ERROR: brew bundle failed"; exit $FAILED; }
 
 # ── Dotfiles ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

The Tart base image has a 50GB disk limit. The full Brewfile fails during the VM acceptance test when GoLand + IntelliJ + PyCharm + Cursor are included (~4GB combined on top of a full macOS install + Homebrew + all CLI tools).

- **`Brewfile.vm`** — new file, same as `Brewfile` minus the four IDEs. Keeps Docker, iTerm2, MongoDB Compass, font, and all CLI tools.
- **`setup.sh`** — respects a `BREWFILE` env var so callers can pass an alternate package list
- **`vm-acceptance-test.sh`** — passes `BREWFILE=Brewfile.vm` when invoking `setup.sh` in the VM

IDEs are still tested on a real machine via the full `Brewfile`. The VM test validates the environment works correctly — tools on PATH, dotfiles symlinked, secrets created, Docker available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)