### PR TITLE
feat: remove JetBrains IDEs, keep Cursor for agentic workflow

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -37,9 +37,6 @@ cask "font-meslo-lg-nerd-font"
 
 # ── GUI Apps ─────────────────────────────────────────────────────────────────
 cask "iterm2"
-cask "cursor"
+cask "cursor"           # AI-first editor (works alongside Claude Code)
 cask "docker"
-cask "goland"
-cask "intellij-idea"
-cask "pycharm"
 cask "mongodb-compass"

--- a/Brewfile.vm
+++ b/Brewfile.vm
@@ -1,10 +1,6 @@
 # Brewfile.vm — used by the VM acceptance test (scripts/vm-acceptance-test.sh)
-# Full environment minus the large JetBrains IDEs and Cursor, which exceed the
-# 50GB Tart base image disk limit. Everything else — CLI tools, Docker, iTerm2,
-# MongoDB Compass, fonts — is included and tested.
-#
-# IDEs omitted: cursor, goland, intellij-idea, pycharm
-# These are covered by the full Brewfile on a real machine.
+# Mirrors the full Brewfile exactly. JetBrains IDEs were removed from the main
+# Brewfile so this file no longer needs to omit anything for disk budget reasons.
 
 # ── Taps ─────────────────────────────────────────────────────────────────────
 tap "homebrew/cask-fonts"
@@ -45,5 +41,6 @@ cask "font-meslo-lg-nerd-font"
 
 # ── GUI Apps ─────────────────────────────────────────────────────────────────
 cask "iterm2"
+cask "cursor"           # AI-first editor (works alongside Claude Code)
 cask "docker"
 cask "mongodb-compass"

--- a/README.md
+++ b/README.md
@@ -101,7 +101,6 @@ To reconfigure MCPs: `bash scripts/setup-mcps.sh`
 | **iTerm2** | Terminal (with custom color profile) |
 | **Cursor** | AI-powered editor |
 | **Docker Desktop** | Container runtime |
-| **GoLand / IntelliJ / PyCharm** | JetBrains IDEs |
 | **MongoDB Compass** | Database GUI |
 | **Meslo LG Nerd Font** | Powerline-compatible font for terminal |
 


### PR DESCRIPTION
## Summary

Removing GoLand, IntelliJ IDEA, and PyCharm from the dev environment. Shifting to Claude Code + Cursor as the primary development workflow — AI-native tooling replaces the traditional IDE suite.

**Cursor stays** — works alongside Claude Code, fits the vibe coding workflow, and is small enough (~500MB) to include in `Brewfile.vm` for VM acceptance tests.

- `Brewfile` — remove `goland`, `intellij-idea`, `pycharm`; keep `cursor`
- `Brewfile.vm` — add `cursor` back (now fits in 50GB VM disk without the JetBrains suite)
- `README.md` — remove JetBrains row from GUI apps table

🤖 Generated with [Claude Code](https://claude.com/claude-code)