### PR TITLE
fix: pre-seed ~/.secrets in VM to skip interactive gh auth login

### DIFF
--- a/scripts/vm-acceptance-test.sh
+++ b/scripts/vm-acceptance-test.sh
@@ -92,6 +92,17 @@ done
 echo "▶ Cloning repository into VM"
 vm_ssh "git clone https://github.com/amcheste/mac-dev-setup ~/Repos/amcheste/mac-dev-setup"
 
+echo "▶ Pre-seeding ~/.secrets with placeholder values (skips interactive credential wizard)"
+vm_ssh 'printf "%s\n" \
+  "# Placeholder secrets for VM acceptance test — not real credentials." \
+  "export ANTHROPIC_API_KEY=\"vm-test-placeholder\"" \
+  "export OCIR_TOKEN=\"vm-test-placeholder\"" \
+  "export OCIR_REGION=\"vm-test-placeholder\"" \
+  "export OCIR_NAMESPACE=\"vm-test-placeholder\"" \
+  "export DIGITAL_OCEAN_TOKEN=\"vm-test-placeholder\"" \
+  "export DB_PASSWORD=\"vm-test-placeholder\"" \
+  > ~/.secrets && chmod 600 ~/.secrets'
+
 echo "▶ Running setup.sh (using Brewfile.vm — excludes large IDEs)"
 vm_ssh "cd ~/Repos/amcheste/mac-dev-setup && BREWFILE=Brewfile.vm bash setup.sh"
 


### PR DESCRIPTION
## Summary

- The VM acceptance test was blocking at `gh auth login` because `setup.sh` calls `setup-credentials.sh` whenever `~/.secrets` is absent (always true in a fresh VM).
- This PR pre-seeds `~/.secrets` with placeholder values before running `setup.sh`, so the credentials check passes and the interactive wizard is skipped entirely.
- The placeholders satisfy the `grep -q 'ANTHROPIC_API_KEY="..*"'` check in `setup.sh:78` — all values are non-empty strings.

## Test plan

- [ ] Re-run `scripts/vm-acceptance-test.sh` locally — should now complete without blocking on `gh auth login`
- [ ] Verify CI validate checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)