### PR TITLE
fix: add Homebrew to PATH in acceptance-test, robust perms check

### DIFF
--- a/scripts/acceptance-test.sh
+++ b/scripts/acceptance-test.sh
@@ -4,6 +4,10 @@
 
 set -euo pipefail
 
+# Ensure Homebrew tools are on PATH — this script runs via non-login bash
+# so .zprofile is never sourced.
+export PATH="/opt/homebrew/bin:/opt/homebrew/sbin:$PATH"
+
 PASS=0
 FAIL=0
 FAILURES=()
@@ -43,9 +47,8 @@ check "$HOME/.vimrc is a symlink" "test -L $HOME/.vimrc"
 
 section "Secrets"
 check "$HOME/.secrets exists" "test -f $HOME/.secrets"
-# shellcheck disable=SC2016
 check "$HOME/.secrets permissions are 0600" \
-  '[[ "$(stat -f \"%Mp%Lp\" '"$HOME"'/.secrets)" == "0600" ]]'
+  "find $HOME/.secrets -maxdepth 0 -perm 0600 | grep -q ."
 
 # ── Tools ──────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- `acceptance-test.sh` runs as `bash /tmp/acceptance-test.sh` — a non-login, non-interactive shell that never sources `.zprofile`. This means `/opt/homebrew/bin` is absent and every `command -v` check fails even though the tools are installed.
- Fixed by adding `/opt/homebrew/bin:/opt/homebrew/sbin` to `PATH` at the top of the script.
- Also replaced the `stat -f "%Mp%Lp"` permissions check with `find -perm 0600` which is unambiguous across macOS versions.

## Test plan

- [ ] Re-run `scripts/vm-acceptance-test.sh` — all tool PATH checks should pass
- [ ] Verify CI validate checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)