### PR TITLE
fix: rename docker cask to docker-desktop

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -35,5 +35,5 @@ cask "font-meslo-lg-nerd-font"
 # ── GUI Apps ─────────────────────────────────────────────────────────────────
 cask "iterm2"
 cask "cursor"           # AI-first editor (works alongside Claude Code)
-cask "docker"
+cask "docker-desktop"
 cask "mongodb-compass"

--- a/Brewfile.vm
+++ b/Brewfile.vm
@@ -39,5 +39,5 @@ cask "font-meslo-lg-nerd-font"
 # ── GUI Apps ─────────────────────────────────────────────────────────────────
 cask "iterm2"
 cask "cursor"           # AI-first editor (works alongside Claude Code)
-cask "docker"
+cask "docker-desktop"
 cask "mongodb-compass"


### PR DESCRIPTION
## Summary

- Homebrew renamed `docker` → `docker-desktop`. Updates both `Brewfile` and `Brewfile.vm` to use the new name and suppress the rename warning on every `brew bundle` run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)