### PR TITLE
feat: add release drafter, auto-labeler, OSSF scorecard, and security policy

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,6 +10,7 @@
 
 - [ ] `shellcheck` passes on all modified scripts
 - [ ] `Brewfile.ci` updated alongside `Brewfile` (if adding CLI tools)
-- [ ] `CHANGELOG.md` updated under `[Unreleased]`
-- [ ] Tested locally — method: <!-- act / new macOS user / UTM / VM acceptance test -->
+- [ ] Tested locally — method: <!-- act / new macOS user / VM acceptance test -->
 - [ ] README updated if adding/removing tools or changing install steps
+
+<!-- Release notes are auto-drafted from this PR's title and labels — no CHANGELOG edit needed. -->

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,23 @@
+brew:
+  - changed-files:
+    - any-glob-to-any-file: ['Brewfile', 'Brewfile.*']
+
+scripts:
+  - changed-files:
+    - any-glob-to-any-file: ['scripts/**']
+
+dotfiles:
+  - changed-files:
+    - any-glob-to-any-file: ['dotfiles/**']
+
+ci:
+  - changed-files:
+    - any-glob-to-any-file: ['.github/**']
+
+formula:
+  - changed-files:
+    - any-glob-to-any-file: ['Formula/**']
+
+docs:
+  - changed-files:
+    - any-glob-to-any-file: ['*.md', 'CLAUDE.md', 'TESTING.md', 'VERSIONING.md']

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,26 +1,54 @@
 name-template: 'v$RESOLVED_VERSION'
 tag-template: 'v$RESOLVED_VERSION'
+
+# ── Auto-label PRs from conventional commit titles ────────────────────────────
+autolabeler:
+  - label: 'breaking-change'
+    title:
+      - '/^(feat|fix|docs|chore|refactor|test|style|perf|ci|build|revert)(\([^)]+\))?!:/i'
+  - label: 'feature'
+    title:
+      - '/^feat(\([^)]+\))?:/i'
+  - label: 'fix'
+    title:
+      - '/^fix(\([^)]+\))?:/i'
+  - label: 'docs'
+    title:
+      - '/^docs(\([^)]+\))?:/i'
+  - label: 'chore'
+    title:
+      - '/^(chore|refactor|test|style|perf|ci|build|revert)(\([^)]+\))?:/i'
+
+# ── Release note categories (driven by labels above) ─────────────────────────
 categories:
+  - title: '⚠️ Breaking Changes'
+    labels: ['breaking-change']
   - title: '🚀 Features'
     labels: ['feature', 'enhancement']
   - title: '🐛 Bug Fixes'
     labels: ['fix', 'bug']
   - title: '📖 Documentation'
-    labels: ['documentation', 'docs']
+    labels: ['docs', 'documentation']
   - title: '🔧 Maintenance'
     labels: ['chore', 'dependencies', 'refactor']
+
 change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
 change-title-escapes: '\<*_&'
+
+# ── Version resolution (labels → semver bump) ─────────────────────────────────
 version-resolver:
   major:
     labels: ['breaking-change']
   minor:
     labels: ['feature', 'enhancement']
   patch:
-    labels: ['fix', 'bug', 'documentation', 'chore', 'dependencies', 'refactor']
+    labels: ['fix', 'bug', 'docs', 'documentation', 'chore', 'dependencies', 'refactor']
   default: patch
+
 exclude-labels:
   - 'skip-changelog'
+
 no-changes-template: '- No notable changes'
+
 template: |
   $CHANGES

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,18 @@
+name: Label PR
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    name: Label
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,21 @@
+name: Release Drafter
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, reopened, synchronize]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-release-draft:
+    name: Update Release Draft
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,40 @@
+name: OpenSSF Scorecard
+
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: '30 1 * * 1'  # Every Monday at 01:30 UTC
+  push:
+    branches: [main]
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard Analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+      contents: read
+      actions: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - uses: ossf/scorecard-action@v2.4.0
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![Version](https://img.shields.io/github/v/tag/amcheste/mac-dev-setup?label=version&sort=semver)](https://github.com/amcheste/mac-dev-setup/releases)
 [![macOS](https://img.shields.io/badge/macOS-Sequoia%2B-000000?logo=apple&logoColor=white)](https://www.apple.com/macos/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/amcheste/mac-dev-setup/badge)](https://scorecard.dev/viewer/?uri=github.com/amcheste/mac-dev-setup)
 
 </div>
 
@@ -192,11 +193,14 @@ Five automated workflows keep the environment reliable across every change and r
 
 | Workflow | Trigger | Purpose |
 |----------|---------|---------|
-| **Validate** | Every PR + push to `main` | Lint, formula audit, macOS integration test |
+| **Validate** | Every PR + push to `main` | Lint, shellcheck, formula audit, macOS integration test, commit lint + semver suggestion |
 | **VM Acceptance** | Release tags + manual | Full install in a clean Tart VM — the release gate |
-| **Release** | `v*.*.*` tags | Validate → acceptance → draft notes → publish release |
+| **Release** | `v*.*.*` tags | Validate → acceptance → publish release |
+| **Release Drafter** | PR open/update + push to `main` | Auto-labels PRs by type, drafts release notes |
+| **Label PR** | PR open/update | Adds content labels (`brew`, `scripts`, `dotfiles`, `ci`) |
 | **Dependency Update** | Weekly (Monday) | Checks Brewfile packages for updates, opens issue if stale |
 | **Stale** | Daily | Closes inactive issues and PRs after 30 + 7 days |
+| **OpenSSF Scorecard** | Weekly + push to `main` | Security posture scoring and SARIF upload |
 
 ### Validate pipeline (every PR)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,12 +1,39 @@
 # Security Policy
 
+## Supported Versions
+
+Only the latest release is actively maintained.
+
+| Version | Supported |
+|---------|-----------|
+| latest  | ✅        |
+| older   | ❌        |
+
 ## Reporting a Vulnerability
 
-Do not open a public GitHub issue for security vulnerabilities.
+**Please do not open a public issue for security vulnerabilities.**
 
-Use GitHub's private vulnerability reporting:
-https://github.com/amcheste/mac-dev-setup/security/advisories/new
+Use GitHub's [private vulnerability reporting](https://github.com/amcheste/mac-dev-setup/security/advisories/new) to report issues confidentially. This ensures the vulnerability can be assessed and patched before public disclosure.
 
-**Scope:** credential leakage in dotfiles or templates, unsafe file permissions, script injection vectors in setup scripts.
+Please include:
+- A clear description of the vulnerability
+- Steps to reproduce
+- Potential impact
 
-**Response time:** best-effort, target 7 days for acknowledgement.
+You can expect an acknowledgement within **7 days** and a resolution or status update within **30 days**.
+
+## Scope
+
+Security-relevant areas in this project:
+
+| Area | Concern |
+|------|---------|
+| `dotfiles/secrets.template` | Must never contain real credentials — only placeholder slots |
+| `scripts/setup-credentials.sh` | Credential prompting and `~/.secrets` file handling |
+| `setup.sh` | Bootstrap execution — runs with user privileges on a fresh machine |
+| `.github/workflows/` | CI/CD pipeline integrity and secret handling |
+
+## Out of Scope
+
+- Preference changes or tool version bumps
+- Issues with third-party tools installed by the Brewfile (report those upstream)


### PR DESCRIPTION
## Summary

Completes the open-source project hygiene pass. Everything here runs automatically with no ongoing maintenance required.

## Changes

**Release Drafter** (`.github/workflows/release-drafter.yml` + updated config)
- Fires on every PR open/update and every push to `main`
- Auto-labels PRs by conventional commit type: `feat:` → `feature`, `fix:` → `fix`, `feat!:` → `breaking-change`, etc.
- Maintains a rolling draft release with categorised notes — ready to publish whenever you tag

**Auto-labeler** (`.github/workflows/labeler.yml` + `.github/labeler.yml`)
- Adds content labels on every PR based on which files changed: `brew`, `scripts`, `dotfiles`, `ci`, `formula`, `docs`
- Complements release drafter's type labels — PRs get both

**OpenSSF Scorecard** (`.github/workflows/scorecard.yml`)
- Runs weekly + on every push to `main`
- Scores the project on 18 security checks (branch protection, dependency pinning, CI, signed releases, etc.)
- Uploads results to GitHub Security tab as SARIF
- Badge added to README header

**SECURITY.md** — expanded with supported versions table, scope table, and out-of-scope section

**PR template** — removed manual `CHANGELOG.md` item (release drafter owns release notes now)

**README** — OSSF badge added, CI/CD workflow table updated to reflect all 8 workflows

## How it works together

```
PR opened
  → labeler adds content labels (brew, scripts, etc.)
  → release-drafter adds type label (feature, fix, chore, breaking-change)
  → commit-lint posts semver suggestion to job summary

PR merged to main
  → release-drafter updates the draft release with the PR entry, resolved version, and category
  
Ready to release
  → /publish-release → bump-version.sh → tag → release pipeline publishes the draft
```

## Test plan

- [ ] CI passes on this PR
- [ ] Labels are applied automatically to this PR (should get `ci` + `feature` from release drafter)
- [ ] Job summary on the Release Drafter run shows a draft being updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)