### PR TITLE
feat: add /create-repo skill and update /publish-release for enforce_admins

### DIFF
--- a/claude-skills/create-repo/SKILL.md
+++ b/claude-skills/create-repo/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: create-repo
+description: Create a new GitHub repository from the amcheste/repo-template, clone it locally, and apply standard branch protection and settings. Use /setup-repo to configure an existing repo instead.
+---
+
+Create a new repository based on the user's request: $ARGUMENTS
+
+## Parse the request
+
+Extract from the user's message:
+- **name**: the repository name (e.g. `my-new-service`). No owner prefix — always created under `amcheste`.
+- **description**: optional one-line description of the repo.
+- **visibility**: `public` (default) or `private`.
+
+If the name is missing or ambiguous, ask before proceeding.
+
+## Pre-flight
+
+Confirm with the user:
+- Repo name: `amcheste/<name>`
+- Description: `<description or "none">`
+- Visibility: `public` or `private`
+
+Do not proceed until confirmed.
+
+## Step 1 — Create from template
+
+```bash
+gh repo create amcheste/<name> \
+  --template amcheste/repo-template \
+  --<public|private> \
+  --description "<description>"
+```
+
+## Step 2 — Clone locally
+
+```bash
+gh repo clone amcheste/<name> ~/Repos/amcheste/<name>
+cd ~/Repos/amcheste/<name>
+```
+
+## Step 3 — Apply standard repo setup
+
+Run the same configuration as `/setup-repo`:
+
+**Create develop branch:**
+```bash
+git checkout -b develop
+git push -u origin develop
+```
+
+**Set develop as default:**
+```bash
+gh api repos/amcheste/<name> \
+  --method PATCH \
+  --field default_branch=develop \
+  --jq '.default_branch'
+```
+
+**Protect develop** (require PR, enforce on admins, all users must go through PR):
+```bash
+gh api repos/amcheste/<name>/branches/develop/protection \
+  --method PUT \
+  --input - <<'EOF'
+{
+  "required_status_checks": {
+    "strict": true,
+    "checks": [{"context": "Lint"}, {"context": "Commit Lint"}]
+  },
+  "enforce_admins": true,
+  "required_pull_request_reviews": {
+    "required_approving_review_count": 0,
+    "dismiss_stale_reviews": false
+  },
+  "restrictions": null,
+  "allow_force_pushes": false,
+  "allow_deletions": false
+}
+EOF
+```
+
+Note: the default checks (`Lint`, `Commit Lint`) match the template's validate.yml. Once you customise the validate workflow, update the required checks accordingly using `/setup-repo`.
+
+**Protect main:**
+```bash
+gh api repos/amcheste/<name>/branches/main/protection \
+  --method PUT \
+  --input - <<'EOF'
+{
+  "required_status_checks": {
+    "strict": true,
+    "checks": [{"context": "Lint"}]
+  },
+  "enforce_admins": true,
+  "required_pull_request_reviews": {
+    "required_approving_review_count": 0,
+    "dismiss_stale_reviews": false
+  },
+  "restrictions": null,
+  "allow_force_pushes": false,
+  "allow_deletions": false
+}
+EOF
+```
+
+**Add tag protection:**
+```bash
+gh api repos/amcheste/<name>/rulesets \
+  --method POST \
+  --input - <<'EOF'
+{
+  "name": "Protect release tags",
+  "target": "tag",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["refs/tags/v*"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    {"type": "deletion"},
+    {"type": "non_fast_forward"},
+    {"type": "creation"}
+  ]
+}
+EOF
+```
+
+## Step 4 — Personalise the repo
+
+Open the following files in the editor and prompt the user to fill them in:
+
+1. **`README.md`** — replace `repo-name` with the actual name, fill in the description
+2. **`CLAUDE.md`** — fill in the "About This Repo" section
+3. **`.github/labeler.yml`** — add project-specific path→label mappings
+4. **`.github/workflows/validate.yml`** — replace the TODO lint step with real commands for this project's language/toolchain
+
+## Summary
+
+Tell the user:
+- Repo URL: `https://github.com/amcheste/<name>`
+- Cloned to: `~/Repos/amcheste/<name>`
+- `develop` is the default branch, protected with required PR + CI
+- `main` is protected — only reachable via develop→main release PR
+- `v*` tags are protected
+- Next: customise `validate.yml` lint steps, then update required status check names with `/setup-repo amcheste/<name>`

--- a/claude-skills/publish-release/SKILL.md
+++ b/claude-skills/publish-release/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: publish-release
-description: Publish a new versioned release. Bumps version on develop, opens a develop→main PR, merges it, tags main, and triggers the release pipeline.
+description: Publish a new versioned release. Opens a version bump PR to develop, merges it, promotes develop to main via PR, tags main, and triggers the release pipeline.
 ---
 
 Publish a new release based on the user's request: $ARGUMENTS
@@ -21,27 +21,38 @@ If the version is ambiguous or missing, ask the user to confirm before proceedin
 4. Confirm `VERSION` file exists in the repo root
 5. Read the current version from `VERSION` and show it to the user before proceeding
 
-## Step 1 — Bump version on develop
+## Step 1 — Version bump PR to develop
 
-Run the bump script:
+Create a short-lived release branch, bump the version, and open a PR to develop:
 
 ```bash
-# Explicit version (including pre-release)
-./scripts/bump-version.sh set <version>
+git checkout -b chore/release-v<version>
 
-# Or a relative increment
-./scripts/bump-version.sh patch   # or minor / major
+# Bump version using the script
+./scripts/bump-version.sh set <version>    # explicit
+./scripts/bump-version.sh patch            # or minor / major
+
+# The script commits with: chore: release v<version>
+# Do NOT push the annotated tag yet — just the commit
+
+git push -u origin chore/release-v<version>
+
+gh pr create \
+  --base develop \
+  --head chore/release-v<version> \
+  --title "chore: release v<version>" \
+  --body "Version bump to v<version>. Merge to proceed with the develop→main release PR."
 ```
 
-The script updates `VERSION`, commits with `chore: release v<version>`, and creates an annotated tag locally. **Do not push the tag yet** — push only the commit:
+Show the user the PR URL. Wait for CI to pass, then ask them to approve and merge it.
+
+## Step 2 — Promote develop → main
+
+After the version bump PR is merged, open the develop→main release PR:
 
 ```bash
-git push origin develop
-```
+git checkout develop && git pull
 
-## Step 2 — Open develop → main PR
-
-```bash
 gh pr create \
   --base main \
   --head develop \
@@ -55,7 +66,7 @@ Show the user the PR URL and ask them to approve and merge it.
 
 ## Step 3 — Tag main after merge
 
-After the user confirms the PR is merged:
+After the user confirms the develop→main PR is merged:
 
 ```bash
 git checkout main && git pull


### PR DESCRIPTION
## Summary

- Adds a new `/create-repo` Claude Code skill that creates a GitHub repo from `amcheste/repo-template`, clones it locally, and applies the full standard branch protection (develop branch, default branch, protection rules, tag ruleset) in one command
- Updates `/publish-release` to work with `enforce_admins: true` on `develop` — the previous flow pushed a version bump commit directly to develop, which is now blocked; the new flow uses a `chore/release-v<version>` branch with a PR to develop, followed by a develop→main release PR before tagging

## Why kept separate from `/setup-repo`

`/create-repo` = brand new repo from template + full setup in one go  
`/setup-repo` = apply standard config to any *existing* repo

## Test plan

- [ ] Invoke `/create-repo my-test-repo` and verify it walks through pre-flight confirmation, creates from template, clones, sets up branches and protection
- [ ] Invoke `/publish-release patch` on a repo with `enforce_admins: true` and verify it creates the release branch and opens a PR to develop (not a direct push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)