### PR TITLE
feat: add missing tools to Brewfile

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,6 +1,10 @@
+# ── Taps ─────────────────────────────────────────────────────────────────────
+tap "cirruslabs/cli"    # tart VM runner
+
 # ── CLI Utilities ────────────────────────────────────────────────────────────
 brew "git"
 brew "gh"               # GitHub CLI
+brew "git-lfs"          # large file support
 brew "vim"
 brew "fzf"
 brew "ripgrep"          # fast grep (rg)
@@ -10,6 +14,7 @@ brew "tmux"
 brew "wget"
 brew "jq"               # JSON processor
 brew "tree"
+brew "tart"             # Apple Silicon VM runner (local acceptance tests)
 
 # ── Languages ────────────────────────────────────────────────────────────────
 brew "go"
@@ -21,19 +26,26 @@ brew "maven"
 # ── Cloud & DevOps ───────────────────────────────────────────────────────────
 brew "kubernetes-cli"   # kubectl
 brew "kind"             # local k8s clusters
+brew "kustomize"        # Kubernetes config management
 brew "helm"
 brew "terraform"
 brew "oci-cli"          # Oracle Cloud
 brew "doctl"            # DigitalOcean CLI
+brew "octant"           # Kubernetes dashboard
 
 # ── Databases ────────────────────────────────────────────────────────────────
 brew "mongosh"          # MongoDB shell
+brew "postgresql@17"    # local Postgres
 
 # ── Fonts ────────────────────────────────────────────────────────────────────
 cask "font-meslo-lg-nerd-font"
 
+# ── Python ───────────────────────────────────────────────────────────────────
+brew "virtualenv"       # Python virtual environments
+
 # ── GUI Apps ─────────────────────────────────────────────────────────────────
 cask "iterm2"
 cask "cursor"           # AI-first editor (works alongside Claude Code)
+cask "claude-code"      # Claude Code CLI
 cask "docker-desktop"
 cask "mongodb-compass"

--- a/Brewfile.ci
+++ b/Brewfile.ci
@@ -5,6 +5,7 @@
 # ── CLI Utilities ────────────────────────────────────────────────────────────
 brew "git"
 brew "gh"
+brew "git-lfs"
 brew "vim"
 brew "fzf"
 brew "ripgrep"
@@ -25,6 +26,7 @@ brew "maven"
 # ── Cloud & DevOps ───────────────────────────────────────────────────────────
 brew "kubernetes-cli"
 brew "kind"
+brew "kustomize"
 brew "helm"
 brew "terraform"
 brew "doctl"


### PR DESCRIPTION
## Summary

Brings the Brewfile in sync with what's actually installed on the machine. These tools were all installed via Homebrew but not tracked:

| Tool | Type | Purpose |
|------|------|---------|
| `tart` | formula (cirruslabs/cli) | Apple Silicon VM runner for local acceptance tests |
| `git-lfs` | formula | Large file support for git |
| `kustomize` | formula | Kubernetes config management |
| `octant` | formula | Kubernetes dashboard |
| `postgresql@17` | formula | Local Postgres |
| `virtualenv` | formula | Python virtual environments |
| `claude-code` | cask | Claude Code CLI |

Also adds the `cirruslabs/cli` tap declaration so `tart` installs cleanly on a fresh machine.

`git-lfs` and `kustomize` also added to `Brewfile.ci`.

## Test plan

- [ ] CI passes (Brewfile audit)
- [ ] Fresh install picks up all new tools via `brew bundle`

🤖 Generated with [Claude Code](https://claude.com/claude-code)