### PR TITLE
fix: run scorecard on develop and add workflow_dispatch

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -5,7 +5,8 @@ on:
   schedule:
     - cron: '30 1 * * 1'  # Every Monday at 01:30 UTC
   push:
-    branches: [main]
+    branches: [main, develop]
+  workflow_dispatch:
 
 permissions: read-all
 


### PR DESCRIPTION
## Summary

- Adds `develop` to the scorecard push trigger so the score is visible before changes reach `main`
- Adds `workflow_dispatch` so it can be triggered manually at any time

## Test plan

- [ ] Merge and verify scorecard run appears on develop push

🤖 Generated with [Claude Code](https://claude.com/claude-code)