### PR TITLE
fix: only publish scorecard results from main branch

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -28,7 +28,8 @@ jobs:
         with:
           results_file: results.sarif
           results_format: sarif
-          publish_results: true
+          # Only publish to scorecard.dev from main — the action enforces this
+          publish_results: ${{ github.ref == 'refs/heads/main' }}
 
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:


### PR DESCRIPTION
## Summary

The `ossf/scorecard-action` enforces that `publish_results: true` can only be used when running from the default branch (`main`). Running it on `develop` causes a verification failure.

Fix: make `publish_results` conditional on the branch — publishes to scorecard.dev only from `main`, but still runs the full scan and uploads SARIF on `develop` for local visibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)