### PR TITLE
fix: silence gruvbox error on first install and clarify GitHub MCP Docker requirement

### DIFF
--- a/dotfiles/vimrc
+++ b/dotfiles/vimrc
@@ -107,7 +107,12 @@ call plug#end()
 
 " ── Theme ──────────────────────────────────────────────────────────────────
 let g:gruvbox_contrast_dark = 'medium'
-colorscheme gruvbox
+" Guard: gruvbox may not be installed yet on first run (vim +PlugInstall)
+try
+  colorscheme gruvbox
+catch /^Vim\%((\a\+)\)\=:E185/
+  colorscheme desert
+endtry
 
 " ── Lightline ──────────────────────────────────────────────────────────────
 set laststatus=2

--- a/scripts/setup-mcps.sh
+++ b/scripts/setup-mcps.sh
@@ -117,9 +117,9 @@ echo "━━━━━━━━━━━━━━━━━━━━━━━━�
 echo "  MCP setup complete!"
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 echo ""
-echo "  Configured servers:"
-claude mcp list 2>/dev/null | sed 's/^/    /' || true
+echo "  Configured servers: github, filesystem, memory, postgres"
 echo ""
-echo "  To verify: claude mcp list"
-echo "  To remove: claude mcp remove <name>"
+echo "  NOTE: GitHub MCP requires Docker to be running."
+echo "        Start Docker Desktop, then verify with: claude mcp list"
+echo "  To remove a server: claude mcp remove <name>"
 echo ""


### PR DESCRIPTION
## Summary

Two polish fixes found during a real install run on the local machine:

**Vim gruvbox error on first run**
On first install `vim +PlugInstall` errors with `E185: Cannot find color scheme 'gruvbox'` because the plugin hasn't downloaded yet when the vimrc is sourced. Wrapped in a `try/catch` that falls back to the built-in `desert` theme — silent on first run, gruvbox loads correctly on all subsequent runs once plugins are installed.

**GitHub MCP shows "Failed to connect" during setup**
`claude mcp list` runs a live health check that tries to start Docker — which isn't running at setup time. Replaced the dynamic health check in the summary with a static server list and a clear note that Docker must be running for the GitHub MCP to connect.

## Test plan

- [ ] Run `setup.sh` — no Vim error output
- [ ] GitHub MCP note is clear in output
- [ ] `claude mcp list` with Docker running shows GitHub MCP connected

🤖 Generated with [Claude Code](https://claude.com/claude-code)