### PR TITLE
fix: suppress vim pager prompt during plugin install

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -66,7 +66,7 @@ bash "$REPO_DIR/scripts/install-dotfiles.sh" \
 echo ""
 echo "▶ Installing Vim plugins..."
 if [[ -f "$HOME/.vim/autoload/plug.vim" ]]; then
-    vim +PlugInstall +qall 2>/dev/null && echo "  Vim plugins installed ✓" \
+    vim --not-a-term -c "set nomore" +PlugInstall +qall 2>/dev/null && echo "  Vim plugins installed ✓" \
         || echo "  Warning: vim +PlugInstall had errors (plugins may still be installed)"
 else
     echo "  vim-plug not found — skipping (run: install-dotfiles.sh first)"


### PR DESCRIPTION
## Summary

`vim-go` outputs enough text during updates to trigger Vim's `-- More --` pager pause, which blocks unattended setup. Fixed by passing `--not-a-term -c "set nomore"` to Vim, which disables the pager without affecting plugin installation.

Tested locally — exits cleanly with code 0, no pager prompt, no error output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)