### PR TITLE
fix: suppress all vim output during plugin install

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -66,7 +66,7 @@ bash "$REPO_DIR/scripts/install-dotfiles.sh" \
 echo ""
 echo "▶ Installing Vim plugins..."
 if [[ -f "$HOME/.vim/autoload/plug.vim" ]]; then
-    vim --not-a-term -c "set nomore" +PlugInstall +qall 2>/dev/null && echo "  Vim plugins installed ✓" \
+    vim --not-a-term -c "set nomore" +PlugInstall +qall >/dev/null 2>&1 && echo "  Vim plugins installed ✓" \
         || echo "  Warning: vim +PlugInstall had errors (plugins may still be installed)"
 else
     echo "  vim-plug not found — skipping (run: install-dotfiles.sh first)"


### PR DESCRIPTION
## Summary

Lightline colour allocation errors were leaking through `2>/dev/null` because they were being written to stdout. Redirect both stdout and stderr to `/dev/null` to give a clean install experience.

🤖 Generated with [Claude Code](https://claude.com/claude-code)