### PR TITLE
fix: add preflight checks and pre-tap cirruslabs/cli before brew bundle

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -19,6 +19,52 @@ echo "  Developer Environment Setup"
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 echo ""
 
+# ── Preflight checks ──────────────────────────────────────────────────────────
+echo "▶ Preflight checks..."
+PREFLIGHT_OK=1
+
+# macOS only
+if [[ "$(uname)" != "Darwin" ]]; then
+    echo "  ERROR: This setup script is for macOS only."
+    exit $FAILED
+fi
+
+# Must be an admin account (member of the 'admin' group)
+if ! id -Gn | tr ' ' '\n' | grep -q '^admin$'; then
+    echo ""
+    echo "  ✗ This account is not an administrator."
+    echo ""
+    echo "  Homebrew and most developer tools require admin (sudo) access."
+    echo "  Please run this script from an admin account, or ask your Mac's"
+    echo "  administrator to run it first."
+    echo ""
+    exit $FAILED
+fi
+echo "  Admin account ✓"
+
+# If Homebrew is already installed, make sure it's functional
+if command -v brew &>/dev/null; then
+    BREW_PREFIX="$(brew --prefix 2>/dev/null)" || BREW_PREFIX=""
+    if [[ -z "$BREW_PREFIX" ]]; then
+        echo "  ✗ Homebrew is installed but not functional."
+        echo "    Try: brew update  or reinstall from https://brew.sh"
+        PREFLIGHT_OK=0
+    elif [[ ! -w "$BREW_PREFIX" ]]; then
+        echo "  ✗ Homebrew prefix '$BREW_PREFIX' is not writable by this user."
+        echo "    Run:  sudo chown -R \$(whoami) $BREW_PREFIX"
+        PREFLIGHT_OK=0
+    else
+        echo "  Homebrew writable ✓"
+    fi
+fi
+
+if [[ $PREFLIGHT_OK -eq 0 ]]; then
+    echo ""
+    echo "  Please fix the issues above and re-run setup.sh."
+    exit $FAILED
+fi
+echo ""
+
 # ── Repos directory ──────────────────────────────────────────────────────────
 if [[ ! -d "$HOME/Repos" ]]; then
     echo "▶ Creating ~/Repos..."
@@ -46,6 +92,11 @@ fi
 echo ""
 echo "▶ Tapping amcheste/mac-dev-setup..."
 brew tap amcheste/mac-dev-setup https://github.com/amcheste/mac-dev-setup 2>/dev/null || true
+
+# Pre-tap third-party taps so brew bundle can resolve their formulae.
+# brew bundle processes taps and formulae together which can cause lookup
+# failures if the tap hasn't been added before the formula is fetched.
+brew tap cirruslabs/cli 2>/dev/null || true
 
 # ── Brew Bundle ──────────────────────────────────────────────────────────────
 echo ""


### PR DESCRIPTION
## Summary

Fixes two bugs found during real-world testing on a second Mac (issues #36 and #37).

### Fix #36 — `tart` not found during `brew bundle`

`brew bundle` can fail to resolve third-party tap formulae if the tap hasn't been added before the fetch stage begins. Fixed by explicitly running `brew tap cirruslabs/cli` before `brew bundle`, guaranteeing `tart` is resolvable regardless of timing.

### Fix #37 — Non-admin account fails silently

When run from a non-admin account (no sudo access), Homebrew can't install and errors are confusing. Added preflight checks at the very top of `setup.sh` that run before anything else:

- **Admin check**: fails immediately with a clear human-readable message if the account is not in the macOS `admin` group
- **Homebrew writability check**: if Homebrew is already installed but the prefix isn't writable by the current user, shows the exact `sudo chown` command needed to fix it

## Test plan

- [ ] CI passes
- [ ] Running as a non-admin user produces a clear error before any installs
- [ ] `tart` installs correctly from a fresh machine without the tap pre-added

Closes #36
Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)