### PR TITLE
fix: remove pull_request trigger from release-drafter workflow

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -3,8 +3,6 @@ name: Release Drafter
 on:
   push:
     branches: [develop, main]
-  pull_request:
-    types: [opened, reopened, synchronize]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary

Release Drafter was failing on all PRs (including Dependabot's) with:

```
Validation Failed: {"resource":"Release","code":"invalid","field":"target_commitish"}
```

When triggered by a `pull_request` event, Release Drafter sets `target_commitish` to the PR's merge ref (`refs/pull/N/merge`), which GitHub rejects as an invalid target for a release.

The `pull_request` trigger was originally added for the autolabeler feature, but that's already handled by the separate `labeler.yml` workflow. Removing it so Release Drafter only runs on pushes to `develop`/`main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)