### PR TITLE
chore: sync Dependabot SHA bumps from main and fix target branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,7 @@ updates:
     schedule:
       interval: weekly
       day: monday
+    target-branch: develop
     commit-message:
       prefix: chore
     labels:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -13,6 +13,6 @@ jobs:
     name: Label
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5
+      - uses: actions/labeler@634933edcd8ababfe52f92936142cc22ac488b1b # v6
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -24,19 +24,19 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: ossf/scorecard-action@ff5dd8929f96a8a4dc67d13f32b8c75057829621 # v2.4.0
+      - uses: ossf/scorecard-action@99c09fe975337306107572b4fdf4db224cf8e2f2 # v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif
           # Only publish to scorecard.dev from main — the action enforces this
           publish_results: ${{ github.ref == 'refs/heads/main' }}
 
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: SARIF file
           path: results.sarif
           retention-days: 5
 
-      - uses: github/codeql-action/upload-sarif@3b1a19a80ab047f35cbb237b5bd9bdc1e14f166c # v3
+      - uses: github/codeql-action/upload-sarif@d4b3ca9fa7f69d38bfcd667bdc45bc373d16277e # v4
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Summary

When the default branch was switched back to `main`, Dependabot started targeting `main` directly. Four PRs merged there before the issue was noticed: #30, #31, #33, #34.

This PR:
- Brings those 4 Action SHA updates into `develop` (resolving merge conflicts by keeping newer versions with pinned SHAs)
- Adds `target-branch: develop` to `dependabot.yml` so all future Dependabot PRs correctly target `develop`

After merging, PR #32 (the release-drafter Dependabot PR still targeting `main`) will be closed — Dependabot will recreate it targeting `develop` on the next run.

**Updated SHAs:**
| Action | From | To |
|--------|------|-----|
| `actions/labeler` | v5 | v6 |
| `ossf/scorecard-action` | v2.4.0 | v2.4.3 |
| `actions/upload-artifact` | v4 | v7 |
| `github/codeql-action` | v3 | v4 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)