### PR TITLE
fix(ci): skip SARIF upload on PRs

### DIFF
--- a/.github/workflows/sast.yml
+++ b/.github/workflows/sast.yml
@@ -29,6 +29,6 @@ jobs:
           generateSarif: "1"
 
       - uses: github/codeql-action/upload-sarif@5c8a8a642e79153f5d047b10ec1cba1d1cc65699 # v3
-        if: always()
+        if: always() && github.event_name != 'pull_request'
         with:
           sarif_file: semgrep.sarif


### PR DESCRIPTION
SARIF upload fails on PRs with 'Resource not accessible by integration'. Limit to push events only.