### PR TITLE
docs: point branching/release sections at engineering handbook

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,17 +40,18 @@ git checkout develop
 
 ---
 
-## Branch Model
+## Branching, Commits, and Releases
 
-| Branch | Purpose |
-|--------|---------|
-| `main` | Always equals the latest published release — stable, never directly committed to |
-| `develop` | Integration branch — all PRs target here |
-| `feature/*`, `fix/*`, etc. | Short-lived branches off `develop` |
+The branching strategy, commit convention, and release process follow the canonical rules documented in Alan's engineering handbook:
 
-PRs go to `develop`. When enough changes accumulate for a release, `develop` is promoted to `main` via the `/publish-release` skill, which opens the develop→main PR automatically.
+- **Why:** [Branching Strategy philosophy](https://github.com/amcheste/engineering-handbook/blob/main/docs/philosophies/branching-strategy.md)
+- **How:** [Branching & Releases workflow](https://github.com/amcheste/engineering-handbook/blob/main/docs/workflows/branching-and-releases.md)
 
-## Development Workflow
+In short: branch from `develop`, one logical change per PR, [Conventional Commits](https://www.conventionalcommits.org/) (`feat:` / `fix:` / `docs:` / `chore:`, `!` for breaking), and releases are cut by `/publish-release` with a CLI merge from `develop` to `main` (never GitHub's merge button).
+
+---
+
+## Development Workflow (repo-local)
 
 Run `shellcheck` on any modified scripts before committing:
 ```bash
@@ -76,21 +77,6 @@ that is not a GUI cask must also appear in `Brewfile.ci`.
 
 ---
 
-## Commit Convention
-
-This project uses [Conventional Commits](https://www.conventionalcommits.org/):
-
-| Prefix | Use |
-|--------|-----|
-| `feat:` | New tool, script, or workflow capability |
-| `fix:` | Bug fix in a script or workflow |
-| `docs:` | README, CHANGELOG, or inline comment changes |
-| `chore:` | Version bumps, dependency updates, housekeeping |
-
-One logical change per PR. Keep commits atomic and the history readable.
-
----
-
 ## Running Acceptance Tests
 
 **Locally (requires Tart):**
@@ -105,26 +91,3 @@ This boots a fresh Sequoia base image, runs `setup.sh` inside the VM, and execut
 [VM Acceptance Test](../../actions/workflows/acceptance.yml) workflow.
 The acceptance workflow also runs automatically on every `v*.*.*` release tag as part of the
 release gate.
-
----
-
-## Release Process
-
-> Only the repo owner publishes releases.
-
-Releases are handled by the `/publish-release` Claude Code skill, which automates the full flow:
-
-1. Bumps version on `develop`, commits `chore: release v<version>`
-2. Opens a PR: `develop → main`
-3. Owner approves and merges the PR
-4. Tags `main` with `v<version>` and pushes the tag
-5. Release pipeline fires automatically: validate → VM acceptance → publish
-
-To trigger manually:
-```bash
-# In Claude Code
-/publish-release 1.0.0
-
-# Or via bump script directly (then follow the steps above)
-./scripts/bump-version.sh patch   # or minor / major / set <version>
-```


### PR DESCRIPTION
## Summary
Points the branching/release sections of \`CONTRIBUTING.md\` at the canonical [engineering-handbook](https://github.com/amcheste/engineering-handbook). Repo-specific content (shellcheck/act/tart prerequisites, \`Brewfile.ci\` parity rule, VM acceptance test flow, fork guidance) is preserved.

### What was wrong
The old \`Release Process\` section said:

> 1. Bumps version on \`develop\`, commits \`chore: release v<version>\`
> 2. **Opens a PR: \`develop → main\`**
> 3. Owner approves and merges the PR

That contradicts the canonical rule (already correctly stated in this repo's \`CLAUDE.md\`) that \`develop → main\` must be a CLI \`git merge --no-ff\` — never a GitHub PR, because GitHub's merge button squash-merges by default and destroys commit ancestry, causing merge conflicts on every subsequent release.

## Follow-ups (flagged for the user)
- Repo's default branch is still \`main\` — should be \`develop\`. Can be fixed with \`/setup-repo amcheste/mac-dev-setup\`.

## Test plan
- [ ] engineering-handbook#6 is merged before this merges (otherwise handbook links 404 temporarily)
- [ ] CONTRIBUTING.md renders cleanly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)